### PR TITLE
Remove 403 errors for directories with an index.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -71,6 +71,8 @@ If your Apache configuration has the `FollowSymLinks` directive enabled, there i
         /var/www/htdocs/sumaserver/      =>  /var/www/app/suma/service/web/
         /var/www/htdocs/suma/client/        =>  /var/www/app/suma/web/
         /var/www/htdocs/suma/analysis/   =>  /var/www/app/suma/analysis/
+        /var/www/htdocs/sumaserver/.htaccess => /var/www/app/suma/.htaccess
+        /var/www/htdocs/suma/.htaccess => /var/www/app/suma/.htaccess
 
 
 Now all of your code is in one place, allowing you to update Suma by running `git pull --rebase origin master`. There is a chance this could result in merge conflicts with your local changes, so please allow for time to resolve these before updating.
@@ -91,6 +93,9 @@ If using Apache's rewrite module add these lines in your web server (likely http
     RewriteCond %{REQUEST_FILENAME} -d
     RewriteRule ^.*$ - [NC,L]
     RewriteRule ^.*$ index.php [NC,L]
+
+    # Allows .htaccess file to be used
+    AllowOverride All
     </Directory>
 
 **Don't forget to change `YOUR_WEB_DIR` to the directory in your web space that contains the `service/web/` content**
@@ -162,6 +167,10 @@ Suma Server Software Configuration
                     name: sumaserver.log
 
     * Be sure that the log directory specified in `sumaserver:log:path` both exists and is **writable by the web server**.
+
+* web/.htaccess
+
+    In the `/SUMA_SERVER_INSTALL_DIR/web/.htaccess` file change `SUMA_BASE_URL` to the path for the Suma Server. 
 
 
 Suma Client Configuration

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -71,9 +71,6 @@ If your Apache configuration has the `FollowSymLinks` directive enabled, there i
         /var/www/htdocs/sumaserver/      =>  /var/www/app/suma/service/web/
         /var/www/htdocs/suma/client/        =>  /var/www/app/suma/web/
         /var/www/htdocs/suma/analysis/   =>  /var/www/app/suma/analysis/
-        /var/www/htdocs/sumaserver/.htaccess => /var/www/app/suma/.htaccess
-        /var/www/htdocs/suma/.htaccess => /var/www/app/suma/.htaccess
-
 
 Now all of your code is in one place, allowing you to update Suma by running `git pull --rebase origin master`. There is a chance this could result in merge conflicts with your local changes, so please allow for time to resolve these before updating.
 
@@ -112,6 +109,17 @@ If using a .htaccess place the file in the `/YOUR_WEB_DIR/sumaserver` directory 
     RewriteRule ^.*$ index.php [NC,L]
 
 An example .htaccess file named can be found at `/YOUR_WEB_DIR/sumaserver/htaccess_example`. To use, copy the contents of this file to a new file named `/YOUR_WEB_DIR/sumaserver/.htaccess`.
+
+403 and 404 Error Handling
+---------------------------
+
+Example .htaccess files with 403 and 404 error handling are available at:
+
+* `/YOUR_WEB_DIR/sumaserver/htaccess_example`
+* `/YOUR_WEB_DIR/analysis/htaccess_example`
+* `/YOUR_WEB_DIR/web/htaccess_example`
+
+Renaming these files to .htaccess will enable custom error handling and give users a 404 error instead of a 403 error when trying to access a forbidden resource.
 
 Database Setup
 ---------------

--- a/analysis/htaccess_example
+++ b/analysis/htaccess_example
@@ -1,0 +1,2 @@
+ErrorDocument 403 SUMA_BASE_URL/client/errors/404.php
+ErrorDocument 404 SUMA_BASE_URL/client/errors/404.php

--- a/service/web/htaccess_example
+++ b/service/web/htaccess_example
@@ -4,3 +4,6 @@ RewriteCond %{REQUEST_FILENAME} -l [OR]
 RewriteCond %{REQUEST_FILENAME} -d
 RewriteRule ^.*$ - [NC,L]
 RewriteRule ^.*$ index.php [NC,L]
+
+ErrorDocument 403 SUMA_BASE_URL/client/errors/404.php
+ErrorDocument 404 SUMA_BASE_URL/client/errors/404.php

--- a/service/web/htaccess_example
+++ b/service/web/htaccess_example
@@ -5,5 +5,8 @@ RewriteCond %{REQUEST_FILENAME} -d
 RewriteRule ^.*$ - [NC,L]
 RewriteRule ^.*$ index.php [NC,L]
 
-ErrorDocument 403 SUMA_BASE_URL/client/errors/404.php
+# For additional security, change 403.php to 404.php
+# This will send a 404 not found error whenever a 403 forbidden error would 
+# have occured.
+ErrorDocument 403 SUMA_BASE_URL/client/errors/403.php
 ErrorDocument 404 SUMA_BASE_URL/client/errors/404.php

--- a/web/errors/403.php
+++ b/web/errors/403.php
@@ -1,0 +1,18 @@
+<?php
+
+header("HTTP/1.0 403 Forbidden");
+
+?>
+<!DOCTYPE html>
+
+<html>
+<head>
+	<title>403 - Forbidden</title>
+</head>
+<body>
+<h1>403 - Forbidden</h1>
+
+<p>We are sorry, but you do not have access to this resource.</p>
+
+</body>
+</html>

--- a/web/errors/404.php
+++ b/web/errors/404.php
@@ -1,0 +1,18 @@
+<?php
+
+header("HTTP/1.0 404 Not Found");
+
+?>
+<!DOCTYPE html>
+
+<html>
+<head>
+	<title>404 - Page Not Found</title>
+</head>
+<body>
+<h1>404 - Page Not Found</h1>
+
+<p>We are sorry, but the page that you requested is not available.</p>
+
+</body>
+</html>

--- a/web/htaccess_example
+++ b/web/htaccess_example
@@ -1,0 +1,2 @@
+ErrorDocument 403 SUMA_BASE_URL/client/errors/404.php
+ErrorDocument 404 SUMA_BASE_URL/client/errors/404.php


### PR DESCRIPTION
IBM AppScan Enterprise monitor flags directories without index files as "Hidden" Directories and considers them to be a security issue. This commit adds a .htaccess file with redirects for 403 and 404 errors to a custom 404.php error page.

Additionally the installation instructions were updated to reflect these changes.