### PR TITLE
Additional metadata in package.json to avoid warnings

### DIFF
--- a/analysis/package.json
+++ b/analysis/package.json
@@ -3,17 +3,10 @@
   "version": "0.0.0",
   "description": "Packages for building the analysis directory of the Suma space assessment toolkit",
   "readme" : "Suma is an open-source mobile web-based assessment toolkit for collecting and analyzing observational data about the usage of physical spaces and services.",
-<<<<<<< HEAD
   "repository" :
-    { "type" : "git"
-      , "url" : "https://github.com/cazzerson/Suma"
-    },
-=======
-  "repository" : 
   { "type" : "git"
   , "url" : "https://github.com/cazzerson/Suma"
   },
->>>>>>> 6f4bf7cf6d1b18baa210377c4e560a2b8837d8e8
   "dependencies": {},
   "devDependencies": {
     "grunt": "0.4.5",

--- a/analysis/package.json
+++ b/analysis/package.json
@@ -2,10 +2,10 @@
   "name": "ang-test",
   "version": "0.0.0",
   "description": "Packages for building the analysis directory of the Suma space assessment toolkit",
-  "readme" : "Suma is an open-source mobile web-based assessment toolkit for collecting and analyzing observational data about the usage of physical spaces and services.",
-  "repository" :
-  { "type" : "git"
-  , "url" : "https://github.com/cazzerson/Suma"
+  "readme": "Suma is an open-source mobile web-based assessment toolkit for collecting and analyzing observational data about the usage of physical spaces and services.",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/cazzerson/Suma"
   },
   "dependencies": {},
   "devDependencies": {

--- a/analysis/package.json
+++ b/analysis/package.json
@@ -1,6 +1,12 @@
 {
   "name": "ang-test",
   "version": "0.0.0",
+  "description": "Packages for building the analysis directory of the Suma space assessment toolkit",
+  "readme" : "Suma is an open-source mobile web-based assessment toolkit for collecting and analyzing observational data about the usage of physical spaces and services.",
+  "repository" :
+    { "type" : "git"
+      , "url" : "https://github.com/cazzerson/Suma"
+    },
   "dependencies": {},
   "devDependencies": {
     "grunt": "0.4.5",


### PR DESCRIPTION
Right now, running 'npm install' on the analysis directory gets several warnings because it's missing some fields that installer hopes to see: description, readme, and repository. This pull request adds the missing fields. 

(I notice that when I grunted the files, it appears to have deleted a bunch of stuff from analysis/reports/scripts/scripts.js -- is that ok? is it not as dire as it seems?)