### PR TITLE
Never disable reporting for errors and warnings.

### DIFF
--- a/analysis/reports/lib/php/Data.php
+++ b/analysis/reports/lib/php/Data.php
@@ -117,7 +117,7 @@ class Data
         }
         else
         {
-           $SUMA_ERROR_REPORTING  = 0;
+           $SUMA_ERROR_REPORTING  = E_ERROR | E_WARNING;
            $SUMA_DISPLAY_ERRORS   = 'off';
         }
 

--- a/analysis/reports/lib/php/RawData.php
+++ b/analysis/reports/lib/php/RawData.php
@@ -35,7 +35,7 @@ class RawData
         }
         else
         {
-           $SUMA_ERROR_REPORTING  = 0;
+           $SUMA_ERROR_REPORTING  = E_ERROR | E_WARNING;
            $SUMA_DISPLAY_ERRORS   = 'off';
         }
 

--- a/analysis/reports/lib/php/ServerIO.php
+++ b/analysis/reports/lib/php/ServerIO.php
@@ -64,7 +64,7 @@ class ServerIO
         }
         else
         {
-            $SUMA_ERROR_REPORTING  = 0;
+            $SUMA_ERROR_REPORTING  = E_ERROR | E_WARNING;
             $SUMA_DISPLAY_ERRORS   = 'off';
         }
 

--- a/analysis/reports/lib/php/SessionsData.php
+++ b/analysis/reports/lib/php/SessionsData.php
@@ -32,7 +32,7 @@ class SessionsData
         }
         else
         {
-           $SUMA_ERROR_REPORTING  = 0;
+           $SUMA_ERROR_REPORTING  = E_ERROR | E_WARNING;
            $SUMA_DISPLAY_ERRORS   = 'off';
         }
 

--- a/analysis/src/lib/php/Data.php
+++ b/analysis/src/lib/php/Data.php
@@ -117,7 +117,7 @@ class Data
         }
         else
         {
-           $SUMA_ERROR_REPORTING  = 0;
+           $SUMA_ERROR_REPORTING  = E_ERROR | E_WARNING;
            $SUMA_DISPLAY_ERRORS   = 'off';
         }
 

--- a/analysis/src/lib/php/RawData.php
+++ b/analysis/src/lib/php/RawData.php
@@ -35,7 +35,7 @@ class RawData
         }
         else
         {
-           $SUMA_ERROR_REPORTING  = 0;
+           $SUMA_ERROR_REPORTING  = E_ERROR | E_WARNING;
            $SUMA_DISPLAY_ERRORS   = 'off';
         }
 

--- a/analysis/src/lib/php/ServerIO.php
+++ b/analysis/src/lib/php/ServerIO.php
@@ -64,7 +64,7 @@ class ServerIO
         }
         else
         {
-            $SUMA_ERROR_REPORTING  = 0;
+            $SUMA_ERROR_REPORTING  = E_ERROR | E_WARNING;
             $SUMA_DISPLAY_ERRORS   = 'off';
         }
 

--- a/analysis/src/lib/php/SessionsData.php
+++ b/analysis/src/lib/php/SessionsData.php
@@ -32,7 +32,7 @@ class SessionsData
         }
         else
         {
-           $SUMA_ERROR_REPORTING  = 0;
+           $SUMA_ERROR_REPORTING  = E_ERROR | E_WARNING;
            $SUMA_DISPLAY_ERRORS   = 'off';
         }
 

--- a/service/web/index.php
+++ b/service/web/index.php
@@ -29,7 +29,7 @@ if ($config['SUMA_DEBUG'] == true)
 }
 else
 {
-    $SUMA_ERROR_REPORTING  = 0;
+    $SUMA_ERROR_REPORTING  = E_ERROR | E_WARNING;
     $SUMA_DISPLAY_ERRORS   = 'off';
     $SUMA_THROW_EXCEPTIONS =  false;
 }


### PR DESCRIPTION
The log level set by Zend overrides the loglevel specified in php.ini (at least in CentOS). The loglevel was getting set to zero when the desire was to stop displaying errors, so Zend was discarding those messages before my php logger could get them.  It seemed like an easy win to simply keep errors and warnings going where previously they were shut off.

You might test this on your distro to verify that it doesn't activate obnoxious behavior. If it does, let me know, and we can see if there is a missing config variable somewhere in php.ini or Zend that can make the behavior consistent across distros.

I think a better, but more complicated long-term solution for logging is to add another user-configured logfile for app-wide error logging.  Like the sumaserver log, the user could specify path and name, but could additionally specify log level and exception throwing. Then you could throw away the separate debug and showerrors settings, and just have one setting to print such info to the screen.  Bonus points would be awarded for printing errors in JSON so that it doesn't break dataResults.

If you think that's a good direction to go, I'd be happy to dive into it.
